### PR TITLE
Explain in pxe.md how to change the port on kayak

### DIFF
--- a/_docs/setup/pxe.md
+++ b/_docs/setup/pxe.md
@@ -94,6 +94,12 @@ use grub.
 pfexec svcadm enable kayak tftp/udp6 dhcp:ipv4
 ```
 
+> If you have something already running on port 80, it's possible to change the
+> port the kayak server uses by running (where 8080 is the port you want):
+> `/var/svc/method/svc-kayak -u nobody -g nobody -p 8080`
+> but if you're running a full fledged webserver on port 80, it might be better
+> to just use that server to serve the directory. 
+
 ## Using the illumos loader (filename "pxeboot")
 
 The configuration for builds using the illumos loader can be found


### PR DESCRIPTION
The kayak webserver by default runs on port 80. Changing this requires
(as far as I know) altering the start/exec line. While there should be
an easier way to do it, until there is, this method should be
documented.

I do take the liberty of pointing out that if you are running a
full-fledged web server on 80, you are better off just using that to
serve the directory.