### PR TITLE
Reflect change of renamed HVM script

### DIFF
--- a/_docs/dev/ec2.md
+++ b/_docs/dev/ec2.md
@@ -23,7 +23,7 @@ need:
 % git clone https://github.com/omniosorg/kayak.git
 % cd kayak
 % wget https://downloads.omnios.org/media/stable/omniosce-{{site.omnios_stable}}.zfs.bz2
-% pfexec ./build/build_xen
+% pfexec ./build/ami
 ```
 > NB: sudo can be used for privilege escalation in place of pexec if you have
 > it configured.


### PR DESCRIPTION
With commit 60931d35 of kayak, build_xen was renamed to build_ami. Sometime later that was shortened to ami.

The rest of this might not be 100% related to this PR, but I'm not sure where to better ask to get an understanding of the state of this functionality. I tried on irc, but maybe phrased myself too vague. I went through the entire process of attempting to create an AMI, but it failed. Likely because I optimistically was hoping the `zpool_patch.c` would be good enough to skip the xen guest. Since no AMI:s seem to have been published since r151030; Do we think it could still be possible to create AMI:s if one would go through the full process?