### PR TITLE
as `ardeshir` pointed out on IRC, the wiki has gone

### DIFF
--- a/_docs/info/getstarted.md
+++ b/_docs/info/getstarted.md
@@ -128,10 +128,3 @@ $ gcc -v
 gcc version 5.5.0 (GCC)
 ```
 
-## More information
-
-This page is a work-in-progress and contributions are very welcome. The
-[system administration page](http://wiki.omniosce.org/GeneralAdministration)
-in the wiki provides some further information that may eventually be
-incorporated into this page.
-


### PR DESCRIPTION
```
[...]
<ardeshir> checking out your wonderful docs, I notices these link was not working: http://wiki.omniosce.org/GeneralAdministration
<ardeshir> The above link is found at the bottom of this page:  https://omnios.org/info/getstarted.html
```